### PR TITLE
Update 2015-10-17-advanced-practical-enum-examples.org

### DIFF
--- a/resources/posts/2015-10-17-advanced-practical-enum-examples.org
+++ b/resources/posts/2015-10-17-advanced-practical-enum-examples.org
@@ -886,8 +886,9 @@ enum Device {
     init?(term: String) {
       if term == "iWatch" {
           self = .AppleWatch
+      } else {
+          return nil
       }
-      return nil
     }
 }
 #+END_SRC


### PR DESCRIPTION
Custom init of Device enum returned nil every time ("Custom Initializers" section)