### PR TITLE
Update 2015-10-17-advanced-practical-enum-examples.org

### DIFF
--- a/resources/posts/2015-10-17-advanced-practical-enum-examples.org
+++ b/resources/posts/2015-10-17-advanced-practical-enum-examples.org
@@ -290,7 +290,7 @@ typealias Config = (RAM: Int, CPU: String, GPU: String)
 // Each of these takes a config and returns an updated config
 func selectRAM(_ config: Config) -> Config {return (RAM: 32, CPU: config.CPU, GPU: config.GPU)}
 func selectCPU(_ config: Config) -> Config {return (RAM: config.RAM, CPU: "3.2GHZ", GPU: config.GPU)}
-func selectGPU(_ config: Config) -> Config {return (RAM: config.RAM, CPU: "3.2GHZ", GPU: "NVidia")}
+func selectGPU(_ config: Config) -> Config {return (RAM: config.RAM, CPU: config.CPU, GPU: "NVidia")}
 
 enum Desktop {
    case Cube(Config)


### PR DESCRIPTION
Fixes a copy+paste error.

It doesn't make sense for `selectGPU` to reset the CPU.