### PR TITLE
"which" -> "that"

### DIFF
--- a/resources/posts/2015-07-19-tuples-swift-advanced-usage-best-practices.org
+++ b/resources/posts/2015-07-19-tuples-swift-advanced-usage-best-practices.org
@@ -149,7 +149,7 @@ drawStreetsOnMap(streets.values)
 
 Here, the tuple is being used as a simple structure for a short interim usecase. Defining a struct would also be possible, but is not strictly necessary.
 
-Another example would be a class which handles algorithmic data, and you're moving an interim result from one method to the next one. Defining an extra struct for something which is only used once in between two or three methods may not be required.
+Another example would be a class that handles algorithmic data, and you're moving an interim result from one method to the next one. Defining an extra struct for something that is only used once in between two or three methods may not be required.
 
 #+BEGIN_SRC Swift
 // Made up algorithm
@@ -167,7 +167,7 @@ There's, of course, a fine line here. Defining a struct for one instance is over
 
 In addition to the previous example, there're also use cases where using tuples beyond a temporary scope is useful. Following Rich Hickey's "If a tree falls in the woods, does it make a sound?" as long as the scope is private and the tuple's type isn't littered over the implementation, using tuples for storing internal state can be fine.
 
-A simple and contrieved example would be storing a static UITableView structure which displays various information from a user profile and contains the key path to the actual value as well as a flag whether the value can be edited when tapping on the cell.
+A simple and contrieved example would be storing a static UITableView structure that displays various information from a user profile and contains the key path to the actual value as well as a flag whether the value can be edited when tapping on the cell.
 
 #+BEGIN_SRC Swift
 let tableViewValues = [(title: "Age", value: "user.age", editable: true),
@@ -220,7 +220,7 @@ Another area where tuples can be used is when you intend to constrain a type to 
 var monthValues: [Int]
 #+END_SRC
 
-However, in this case we don't know whether the property indeed contains 12 elements. A user of our object could accidentally insert 13 values, or 11. We can't tell the type checker that this is a fixed size array of 12 items[fn:: Interestingly, something which C can do just fine]. With tuples, this specific constraint can easily be put into place:
+However, in this case we don't know whether the property indeed contains 12 elements. A user of our object could accidentally insert 13 values, or 11. We can't tell the type checker that this is a fixed size array of 12 items[fn:: Interestingly, something that C can do just fine]. With tuples, this specific constraint can easily be put into place:
 
 #+BEGIN_SRC Swift
 var monthValues: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int)
@@ -242,7 +242,7 @@ func sumOf(numbers: Int...) -> Int {
 sumOf(1, 2, 5, 7, 9) // 24
 #+END_SRC
 
-Tuples can be useful here if your requirement goes beyond simple integers. Take this function which does a batch update of =n= entities in a database:
+Tuples can be useful here if your requirement goes beyond simple integers. Take this function, which does a batch update of =n= entities in a database:
 
 #+BEGIN_SRC Swift
 func batchUpdate(updates: (String, Int)...) -> Bool {
@@ -407,7 +407,7 @@ Even better, for functional programming, you can return a tuple with multiple pa
 
 
 [[https://twitter.com/J7zz][Bernd Ohr]] has a nice example that shows how tuples can be used to reorder function parameters.
-In his example, he's creating a simple =Banana struct=, a function =createBanana=, and a =tuple typealias= which has the same parameters as the function:
+In his example, he's creating a simple =Banana struct=, a function =createBanana=, and a =tuple typealias= that has the same parameters as the function:
 
 #+BEGIN_SRC swift :noweb-ref bananas
 struct Banana { 


### PR DESCRIPTION
Fantastic article! Thanks!

The rule is: use “that” to introduce a restrictive clause, which tells the reader the kind of a thing. Use “, which” to introduce a clause that merely adds information about the thing.