### PR TITLE
Add missing dots for cases in enum Trade

### DIFF
--- a/resources/posts/2015-10-17-advanced-practical-enum-examples.org
+++ b/resources/posts/2015-10-17-advanced-practical-enum-examples.org
@@ -561,8 +561,8 @@ enum Trade: CustomStringConvertible {
    case Buy, Sell
    var description: String {
        switch self {
-           case Buy: return "We're buying something"
-           case Sell: return "We're selling something"
+           case .Buy: return "We're buying something"
+           case .Sell: return "We're selling something"
        }
    }
 }


### PR DESCRIPTION
This is in Advanced Enum Usage
Protocols section. Great article btw!