### PR TITLE
Proposition to edit post by adding an optional extension where Self == Error

### DIFF
--- a/resources/posts/2018-01-10-optional-extensions.org
+++ b/resources/posts/2018-01-10-optional-extensions.org
@@ -116,6 +116,43 @@ func build_car() throws -> Car {
 }
 #+END_SRC
 
+Usefull way to write `do {} catch {}` more descriptive
+
+```+BEGIN_SRC swift
+// Throw handling
+
+/// Returns an Optional Error if the function throws
+func should(_ function: () throws -> Void) -> Error? {
+    do {
+        try function()
+        return nil
+    } catch {
+        return error
+    }
+}
+
+extension Optional where Wrapped == Error {
+    /// Performs else if self is nil
+    func or(_ else: (Error) -> Void) {
+        if let error = self {
+            `else`(error)
+        } else {
+            return
+        }
+    }
+}
+```+END_SRC
+
+You can write code like:
+
+```+BEGIN_SRC swift
+func throwingFunction() throws {
+  // do something
+}
+
+should { try throwingFunction()}.or(print($0))
+```+END_SRC
+
 ** Map
 
 As we saw above, =map= and =flatMap= are the only methods that Swift offers on Optionals. However, even those can be improved a bit to be more versatile in many situations. There're two additional variations on =map= that allow defining a default value similar to how the =or= variants above are implemented:
@@ -127,7 +164,7 @@ As we saw above, =map= and =flatMap= are the only methods that Swift offers on O
     func map<T>(_ fn: (Wrapped) throws -> T, or default: T) rethrows -> T {
         return try map(fn) ?? `default`
     }
-    
+
     /// Maps the output *or* returns the result of calling `else`
     /// - parameter fn: The function to map over the value
     /// - parameter else: The function to call if the optional is empty

--- a/resources/posts/2018-01-10-optional-extensions.org
+++ b/resources/posts/2018-01-10-optional-extensions.org
@@ -122,12 +122,24 @@ Usefull way to write `do {} catch {}` more descriptive
 // Throw handling
 
 /// Returns an Optional Error if the function throws
-func should(_ function: () throws -> Void) -> Error? {
+/// - parameter do: funtion that can throw to be performed. If the function throws it returns an Optional Error.
+func should(_ do: () throws -> Void) -> Error? {
     do {
-        try function()
+        try `do`()
         return nil
     } catch {
         return error
+    }
+}
+
+extension Optional where Wrapped == Error {
+    /// Performs else if self is nil
+    func or(_ else: (Error) -> Void) {
+        if let error = self {
+            `else`(error)
+        } else {
+            return
+        }
     }
 }
 


### PR DESCRIPTION
Added proposition to add a more descriptive throw handling using optional extension on Error.

Basically I write a lot of code than just prints the error. Although `do {} catch {}` is common in many languages I get a lot of developers that do not like the syntax. Maybe this is more descriptive?